### PR TITLE
(possibly?) fixed a fact about eigenvectors

### DIFF
--- a/eigenvaluesAndEigenvectors/definition.tex
+++ b/eigenvaluesAndEigenvectors/definition.tex
@@ -21,7 +21,7 @@ Given a square matrix, then, the {\it eigenvalue problem} is to find a complete 
 
 Before proceeding with examples, we note that
 
-\begin{proposition} If $\bf v$ is an eigenvalue of a matrix $A$, the eigenvector associated with it is unique.
+\begin{proposition} If $\bf v$ is an eigenvector of a matrix $A$, the eigenvalue associated with it is unique.
 \end{proposition}
 
 \begin{proof} Suppose $\lambda_1{\bf v} = A*{\bf v} = \lambda_2{\bf v}$. Then $\lambda_1{\bf v} - \lambda_2{\bf v} = (\lambda_1 - \lambda_2){\bf v} = {\bf 0}$. But since ${\bf v}\ne {\bf 0}$, the only way this could happen is if the coefficient $(\lambda_1 - \lambda_2)$ is equal to zero, or equivalently, if $\lambda_1 = \lambda_2$.


### PR DESCRIPTION
Was this meant to say what I've proposed? Because as stated, I am not sure if the proposition is correct. Let for a counter example A = [0 1; 1 0]. Then consider the column vectors a=[1; 1] and b=[-1; -1]. For the eigenvalue y=1, both vectors a and b are eigenvectors (because A*v = 1*v for both a and b), correct? So I think one eigenvalue may have many associated eigenvectors; but one eigenvector (I believe) always has a unique eigenvalue.    
        
Edit: corrected the b vector